### PR TITLE
Updated OpenOCD to Support Fin v1.1.0 (Removed FTDI)

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -2,7 +2,6 @@ FROM resin/%%RESIN_MACHINE_NAME%%-buildpack-deps
 
 # install required packages
 RUN apt-get update && apt-get install -yq --no-install-recommends \
-    ftdi-eeprom \
     git \
     build-essential \
     libtool \
@@ -11,7 +10,6 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     automake \
     texinfo \
     libusb-1.0 \
-    libftdi-dev \
     screen \
     telnet \
     make && \
@@ -20,10 +18,10 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 # define our working directory in the container
 WORKDIR usr/src/app
 
-# Move app to filesystem
+# move app to filesystem
 COPY ./app ./
 
-# Clone opnecd repo
+# clone openocd repo, configure for balena fin and build
 RUN git clone git://git.code.sf.net/p/openocd/code openocd-code && \
   cd openocd-code && chmod -R +x bootstrap && ./bootstrap && ./configure --enable-sysfsgpio --enable-bcm2835gpio && make && \
   make install
@@ -31,5 +29,5 @@ RUN git clone git://git.code.sf.net/p/openocd/code openocd-code && \
 # enable systemd init system in the container
 ENV INITSYSTEM on
 
-# Start app
+# start app
 CMD ["bash", "/usr/src/app/start.sh"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -24,8 +24,8 @@ WORKDIR usr/src/app
 COPY ./app ./
 
 # Clone opnecd repo
-RUN git clone --depth 1 git://git.code.sf.net/p/openocd/code openocd-code && \
-  cd openocd && chmod -R +x bootstrap && ./bootstrap && ./configure --enable-sysfsgpio --enable-bcm2835gpio && make && \
+RUN git clone git://git.code.sf.net/p/openocd/code openocd-code && \
+  cd openocd-code && chmod -R +x bootstrap && ./bootstrap && ./configure --enable-sysfsgpio --enable-bcm2835gpio && make && \
   make install
 
 # enable systemd init system in the container

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -24,8 +24,8 @@ WORKDIR usr/src/app
 COPY ./app ./
 
 # Clone opnecd repo
-RUN git clone --depth 1 https://github.com/resin-io-modules/FT2232H-56Q-openocd.git && \
-  cd FT2232H-56Q-openocd && chmod -R +x ./* && autoreconf -f -i && ./configure && make && \
+RUN git clone --depth 1 git://git.code.sf.net/p/openocd/code openocd-code && \
+  cd openocd && chmod -R +x bootstrap && ./bootstrap && ./configure --enable-sysfsgpio --enable-bcm2835gpio && make && \
   make install
 
 # enable systemd init system in the container

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-# [WIP] resin-ft2232h-56q-openocd-efm32
-a resin application that allows to flash an efm32 microcontroller via a FTDI FT2232H-56Q USB chip
+# Program Artik 020 using the Resin Fin
+This is a resin application that allows for flashing of the Artik 020 microcontroller via a the Resin Fin's GPIO pins.
 
 ### How to use
 
-- Setup your resin.io account and push to your application following [this guide](https://docs.resin.io/raspberrypi3/nodejs/getting-started/#account-setup)
-- Open 2 appication container terminals from the dashboard
-  - in the first shell, type `openocd -f interface/ftdi/2232h-cp.cfg -f target/efm32.cfg`
-  - in the second shell, right afterwards, type `telnet localhost 4444` -> `reset` -> `program /usr/src/app/firmware/soc-empty.bin`
+- Setup your [resin.io](https://resin.io) account and push to your application following [this guide](https://docs.resin.io/raspberrypi3/nodejs/getting-started/#account-setup)
+- Open an application container (main) terminal from the resin dashboard
+  - Within the terminal's shell, type `telnet localhost 4444` -> `reset` -> `program ./firmware/soc-empty.bin`

--- a/app/balena.cfg
+++ b/app/balena.cfg
@@ -1,0 +1,23 @@
+interface bcm2835gpio
+
+# Set parameters for Balena Fin
+bcm2835gpio_peripheral_base 0x3F000000
+bcm2835gpio_speed_coeffs 194938 48
+bcm2835gpio_jtag_nums 11 25 10 9
+bcm2835gpio_swd_nums 25 24
+bcm2835gpio_srst_num 18
+
+transport select swd
+
+# Set parameters for Artik 020
+set CHIPNAME efm32
+source [find target/efm32.cfg]
+
+reset_config srst_nogate
+
+adapter_nsrst_delay 100
+adapter_nsrst_assert_width 100
+
+init
+reset halt
+poll

--- a/app/start.sh
+++ b/app/start.sh
@@ -1,6 +1,2 @@
-echo "Loading ftdi_sio module..."
-modprobe -r ftdi_sio
-sleep 2
-echo "Flashing FTDI EEPROM..."
-ftdi_eeprom --flash-eeprom FT2232H-56Q-openocd/other/jtag.conf
-echo "FTDI Ready. Run <openocd -f interface/ftdi/2232h-cp.cfg -f target/efm32.cfg> then open a new terminal and run <telnet localhost 4444> -> <reset> -> <program ./firmware/soc-empty.bin>"
+echo "Preparing Artik 020 for debug/programming..."
+openocd -f balena.cfg


### PR DESCRIPTION
Removed FTDI instructions/dependencies and changed programmer to RPi GPIO bit-banged SWD.

@curcuz @ntzovanis not sure if this should be pulled into this repo or if it should live in its own repo? 